### PR TITLE
Update routing for gh-pages

### DIFF
--- a/src/static/js/main.js
+++ b/src/static/js/main.js
@@ -5,7 +5,7 @@
 global.$ = require( 'jquery' );
 (function(){
 
-if(location.pathname !== '/' && !location.pathname.match('/index.html')) return
+if ( !document.querySelector( '#submit-quiz' ) ) return
 
 var SCORING = {
   'read-self': {
@@ -60,13 +60,20 @@ $(document).ready(function(){
   $(document).on('submit', function(e){
     e.preventDefault()
     var formValues = {}
+    var pathname = window.location.pathname
+    var resultsPagePath = ''
+    if ( pathname.match( 'index.html' ) ) {
+      resultsPagePath = pathname.replace( 'index.html', 'results.html?' )
+    } else {
+      resultsPagePath = pathname + 'results.html?'
+    }
 
     $('#quiz-form').serialize().split('&').forEach(function(v){
       var keyval = v.split('=')
       formValues[keyval[0]] = keyval[1]
     })
 
-    location = '/results.html?' + SCORING[formValues['method']][formValues['age']][
+    location = resultsPagePath + SCORING[formValues['method']][formValues['age']][
         Object.keys(formValues).filter(function(key){
           return key.indexOf('quest') === 0
         }).reduce(function(a, b){

--- a/src/static/js/results.js
+++ b/src/static/js/results.js
@@ -9,18 +9,20 @@ var HIGH = 64
 
 var resourcesByScore = [
   {
-    graph: '/improvement.png',
+    graph: 'improvement.png',
     wellBeing: 'Could be improved'
   },
   {
-    graph: '/average.png',
+    graph: 'average.png',
     wellBeing: 'Average'
   },
   {
-    graph: '/high.png',
+    graph: 'high.png',
     wellBeing: 'High'
   }
 ]
+
+var imgPath = window.location.pathname.replace( 'results.html', '' ) + 'static/img/'
 
 function getResourcesByScore(score){
   if(score < AVERAGE) return resourcesByScore[0]
@@ -35,7 +37,7 @@ function loadResources(score, resources){
 
   $(header).text(header.text() + ' ' + score)
   $(blurb).text(blurb.text() + ' ' + resources.wellBeing)
-  graph.attr('src', '/static/img' + resources.graph)
+  graph.attr('src', imgPath + resources.graph)
 }
 
 


### PR DESCRIPTION
Update the routing to be a little more path agnostic to let this get served via gh-pages:

- Change the guard condition in `main.js` to check for the submit button instead of a specific path (that will make the JS work from either `/` or `/index.html`)
- Change the route to the results page to work from either `/` or `/index.html`
- Change the path to the graph images to work from the gh-pages URL of `/financial-well-being/`